### PR TITLE
Fixed earlier syntax and type errors

### DIFF
--- a/Kerbanomics/Kerbanomics.cs
+++ b/Kerbanomics/Kerbanomics.cs
@@ -329,30 +329,34 @@ namespace Kerbanomics
             GUILayout.FlexibleSpace();
             if (GUILayout.Button("Calculate"))
             {
-                float intMult = CalcInterest() / 100;
-                amountFinanced = reqAmount * (intMult + 1);
-                estPayment = amountFinanced / payments;
-                Debug.Log("Financed: " + amountFinanced);
-                Debug.Log("Estimated Payment: " + estPayment);
-                Debug.Log("Interest: " + intMult);
+                //float intMult = CalcInterest() / 100;
+                //amountFinanced = reqAmount * (intMult + 1);
+                //estPayment = amountFinanced / payments;
+                //Debug.Log("Financed: " + amountFinanced);
+                //Debug.Log("Estimated Payment: " + estPayment);
+                //Debug.Log("Interest: " + intMult);
                 
                 //Here is a set of calculations using compound interest instead of the above calcs
                 float APR = CalcInterest();
                 //50% annual rates are HUGE.  A more sensible range of rates might be 3-20%, for now let's use the existing code
+                //After running this calc a few times, 50% is not too bad on a small number of payments
+                
                 //there are 4 periods per year, so the period percentage is:
-                float periodRate = 100*(Math.Pow((1+APR/100),(1.0/4))-1); //gives the rate in %
+                float periodRate = (float)(100*(Math.Pow((1+APR/100),(1.0/4))-1)); //gives the rate in %
+                
                 //the next calculation gives the payment value including the interest accrued over the life of the loan
-                float paymentValue = (1.0/(periodRate/100))*(1 - 1.0/(Math.Pow((1+periodRate/100),payments)));
+                float paymentValue = (float)((1.0/(periodRate/100))*(1 - 1.0/(Math.Pow((1+periodRate/100),payments))));
                 
                 //the estimated payment is the loan principle (required amount) divided by the payment value
                 estPayment = reqAmount / paymentValue;
                 
                 //the total loan to be repayed is given by the estimated payment times the number of periods for the life of the loan
                 amountFinanced = estPayment*payments; 
-                Debug.Log("Compound Financed: " + amountFinanced);
-                Debug.Log("Estimated Payment: " + estPayment);
                 Debug.Log("Annual Interest Rate (APR): " + APR);
                 Debug.Log("paymentValue: " + paymentValue);
+                Debug.Log("Compound Financed: " + amountFinanced);
+                Debug.Log("Estimated Payment: " + estPayment);
+               
                 /*what should really be done is to keep track of the per period interest rate and the following steps
                 would look like a real loan:
                 At the loan disbursement, apply the value of the loan, only, as the financed amount.
@@ -365,6 +369,8 @@ namespace Kerbanomics
                 A simple check making the max payment no larger than the remaining principle*(1+periodRate) would eliminate overpaying
                 the loan.
                 */
+
+
             }
             if (amountFinanced != 0)
             {


### PR DESCRIPTION
Earlier commit required some additional casts to make the Math.Pow
functions play nice.

I checked the math against an excel spread-sheet I have and it's working
out for the given APR and payment# for 4-payments per year.
